### PR TITLE
ci: Speed up rpm builds in CI

### DIFF
--- a/Containerfile.mock
+++ b/Containerfile.mock
@@ -1,4 +1,4 @@
 FROM fedora:38
 
 RUN dnf -y update
-RUN dnf -y install mock make copr-cli txt2man groff
+RUN dnf -y install mock make copr-cli txt2man groff qemu-user-static-*


### PR DESCRIPTION
Cache most of the chroot used to build rpms in a container image that is prebuilt and pushed to quay.io.