### PR TITLE
nexd: Remove some firstTime code for reconciliation

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/nexodus-io/nexodus/internal/stun"
 	"net"
 	"net/http"
 	"net/netip"
@@ -18,6 +17,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/nexodus-io/nexodus/internal/stun"
 
 	"github.com/nexodus-io/nexodus/internal/api/public"
 	"github.com/nexodus-io/nexodus/internal/client"
@@ -434,20 +435,17 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		}
 	}
 
-	err = util.RetryOperation(ctx, retryInterval, maxRetries, func() error {
-		if err := ax.Reconcile(true); err != nil {
-			if err != nil {
-				ax.logger.Warnf("initial reconciliation failed - retrying: %v", err)
-				return err
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("initial reconciliation failed: %w", err)
-	}
-
 	util.GoWithWaitGroup(wg, func() {
+		// kick it off with an immediate reconcile
+		ax.reconcileDevices(ctx, options)
+
+		for _, proxy := range ax.ingressProxies {
+			proxy.Start(ctx, wg, ax.userspaceNet)
+		}
+		for _, proxy := range ax.egressProxies {
+			proxy.Start(ctx, wg, ax.userspaceNet)
+		}
+
 		stunTicker := time.NewTicker(time.Second * 20)
 		defer stunTicker.Stop()
 		pollTicker := time.NewTicker(pollInterval)
@@ -468,13 +466,6 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		}
 	})
 
-	for _, proxy := range ax.ingressProxies {
-		proxy.Start(ctx, wg, ax.userspaceNet)
-	}
-	for _, proxy := range ax.egressProxies {
-		proxy.Start(ctx, wg, ax.userspaceNet)
-	}
-
 	return nil
 }
 
@@ -490,7 +481,7 @@ func (ax *Nexodus) Stop() {
 
 func (ax *Nexodus) reconcileDevices(ctx context.Context, options []client.Option) {
 	var err error
-	if err = ax.Reconcile(false); err == nil {
+	if err = ax.Reconcile(); err == nil {
 		return
 	}
 
@@ -570,7 +561,7 @@ func (ax *Nexodus) reconcileStun(deviceID string) error {
 			ax.logger.Debugf("update device response %+v", res)
 			ax.nodeReflexiveAddressIPv4 = reflexiveIP
 			// reinitialize peers if the NAT binding has changed for the node
-			if err = ax.Reconcile(true); err != nil {
+			if err = ax.Reconcile(); err != nil {
 				ax.logger.Debugf("reconcile failed %v", res)
 			}
 		}
@@ -579,7 +570,7 @@ func (ax *Nexodus) reconcileStun(deviceID string) error {
 	return nil
 }
 
-func (ax *Nexodus) Reconcile(firstTime bool) error {
+func (ax *Nexodus) Reconcile() error {
 	peerListing, resp, err := ax.informer.Execute()
 	if err != nil {
 		if resp != nil {
@@ -589,28 +580,6 @@ func (ax *Nexodus) Reconcile(firstTime bool) error {
 		}
 	}
 	var newPeers []public.ModelsDevice
-	if firstTime {
-		// Initial peer list processing branches from here
-		ax.logger.Debugf("Initializing peers for the first time")
-		for _, p := range peerListing {
-			existing, ok := ax.deviceCache[p.Id]
-			if !ok {
-				ax.deviceCache[p.Id] = p
-				newPeers = append(newPeers, p)
-			} else if !reflect.DeepEqual(existing, p) {
-				ax.deviceCache[p.Id] = p
-				newPeers = append(newPeers, p)
-			}
-		}
-		ax.buildPeersConfig()
-		if err := ax.DeployWireguardConfig(newPeers, firstTime); err != nil {
-			if errors.Is(err, interfaceErr) {
-				ax.logger.Fatal(err)
-			}
-			return err
-		}
-	}
-	// all subsequent peer listings updates get branched from here
 	changed := false
 	for _, p := range peerListing {
 		existing, ok := ax.deviceCache[p.Id]
@@ -618,8 +587,7 @@ func (ax *Nexodus) Reconcile(firstTime bool) error {
 			changed = true
 			ax.deviceCache[p.Id] = p
 			newPeers = append(newPeers, p)
-		}
-		if !reflect.DeepEqual(existing, p) {
+		} else if !reflect.DeepEqual(existing, p) {
 			changed = true
 			ax.deviceCache[p.Id] = p
 			newPeers = append(newPeers, p)
@@ -629,7 +597,10 @@ func (ax *Nexodus) Reconcile(firstTime bool) error {
 	if changed {
 		ax.logger.Debugf("Peers listing has changed, recalculating configuration")
 		ax.buildPeersConfig()
-		if err := ax.DeployWireguardConfig(newPeers, false); err != nil {
+		if err := ax.DeployWireguardConfig(newPeers); err != nil {
+			// If the wireguard configuration fails, we should wipe out our peer list
+			// so it is rebuilt and reconfigured from scratch the next time around.
+			ax.wgConfig.Peers = nil
 			return err
 		}
 	}

--- a/internal/nexodus/nexodus_unix.go
+++ b/internal/nexodus/nexodus_unix.go
@@ -1,0 +1,7 @@
+//go:build linux || darwin
+
+package nexodus
+
+import "errors"
+
+var interfaceErr = errors.New("interface setup error")

--- a/internal/nexodus/wg_deploy.go
+++ b/internal/nexodus/wg_deploy.go
@@ -8,7 +8,7 @@ const (
 	persistentKeepalive = "20"
 )
 
-func (ax *Nexodus) DeployWireguardConfig(newPeers []public.ModelsDevice, firstTime bool) error {
+func (ax *Nexodus) DeployWireguardConfig(newPeers []public.ModelsDevice) error {
 	cfg := &wgConfig{
 		Interface: ax.wgConfig.Interface,
 		Peers:     ax.wgConfig.Peers,
@@ -20,24 +20,16 @@ func (ax *Nexodus) DeployWireguardConfig(newPeers []public.ModelsDevice, firstTi
 		}
 	}
 
-	// add routes and tunnels for all peer candidates without checking cache since it has not been built yet
-	if firstTime {
-		for _, peer := range cfg.Peers {
-			ax.handlePeerRoute(peer)
-			ax.handlePeerTunnel(peer)
-		}
-		return nil
-	}
-
 	// add routes and tunnels for the new peers only according to the cache diff
 	for _, newPeer := range newPeers {
-		if newPeer.Id != "" {
-			// add routes for each peer candidate (unless the key matches the local nodes key)
-			for _, peer := range cfg.Peers {
-				if peer.PublicKey == newPeer.PublicKey && newPeer.PublicKey != ax.wireguardPubKey {
-					ax.handlePeerRoute(peer)
-					ax.handlePeerTunnel(peer)
-				}
+		if newPeer.Id == "" {
+			continue
+		}
+		// add routes for each peer candidate (unless the key matches the local nodes key)
+		for _, peer := range cfg.Peers {
+			if peer.PublicKey == newPeer.PublicKey && newPeer.PublicKey != ax.wireguardPubKey {
+				ax.handlePeerRoute(peer)
+				ax.handlePeerTunnel(peer)
 			}
 		}
 	}

--- a/internal/nexodus/wg_iface.go
+++ b/internal/nexodus/wg_iface.go
@@ -1,7 +1,6 @@
 package nexodus
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -16,8 +15,6 @@ const (
 	fwdFilePathV6  = "/proc/sys/net/ipv6/conf/all/forwarding"
 	nftablesBinary = "nft"
 )
-
-var interfaceErr = errors.New("interface setup error")
 
 // ifaceExists returns true if the input matches a net interface
 func ifaceExists(logger *zap.SugaredLogger, iface string) bool {


### PR DESCRIPTION
In general, to have the most robust reconciliation possible, we should no reconciliation related code that runs differently the first time vs. subsequent times. This change moves the code in that direction.

nexd was blocking during startup on completion of the first reconcile call. It dow defers that to the reconciliation go routine. The only functional difference is that if the first reconciliation fails, we no longer exit the process. It will keep trying and logging each failed attempt, which I believe is more desirable behavior.

The Reconcile() method took a `firstTime` parameter, but the difference in behavior was very minor. The only functoinal differences were an additional debug log message and a fatal log message if setting up the wireguard config failed. Instead, nexd will come back around and try again on each reconcile attempt.

The Reconcile() method also had a bug in building the newPeers list. A previous commit, d616d84011b447e9f6cfd2e64cef615211c84902, fixed a case where peers would be duplicated in the newPeers list. Unfortunately, that only fixed it in the copy of the code run for the first reconcile. This change includes the same fix for every reconciliation run. Now there should no longer ever be duplicates in that list.

DeployWireguardConfig() no longer takes a `firstTime` parameter. The intention was to ensure handlePeerRoute() and handlePeerTunnel() are always called, but it happens anyway, because the newPeers list is the full list of peers the first time it is called. We now also ensure the full list is processed again anytime the wireguard configuration fails and not just the first time.